### PR TITLE
Handled the promise for the lat/long case and returned as json

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,7 +6,17 @@ module.exports = ( city, long ) => {
 
     if ( long === Number( long ) && city === Number( city ) ) {
 
-        return fetch( str + `lat=${city}&lon=${long}` )
+        return fetch( str + `lat=${city}&lon=${long}` ).then( response => {
+
+          if ( response.status >= 400 ) {
+
+            throw new Error( 'Bad response from server' )
+
+          }
+
+          return response.json()
+          
+        })
 
     } else if ( city !== Number( city ) ) {
 


### PR DESCRIPTION
I was using this module to get a weather forecast using lat/long, not city, and instead of JSON it was returning a buffer object. Looking at the code, it was clear that the promise for the lat/long data was not handled, so I added a return statement for the promise. Kept style consistent with the project.